### PR TITLE
Devour can handle files with spaces now

### DIFF
--- a/devour.sh
+++ b/devour.sh
@@ -2,5 +2,17 @@
 
 id=$(xdo id)
 xdo hide
-sh -c "$*" >/dev/null 2>&1
+whitespace="[[:space:]]"
+args=()
+for i in "$@"
+do
+    if [[ $i =~ $whitespace ]]
+    then
+        i=\'$i\'
+    fi
+   args+="$i " 
+done
+
+sh -c "$args" >/dev/null 2>&1
+
 xdo show "$id"


### PR DESCRIPTION
While using this program, I realized devour cannot handle arguments with spaces that are usually handled. `zathura "File Space.pdf"` works in the command line, but `devour zathura "File Space.pdf"` does not, same with `devour zathura File\ Space.pdf`. You can combine the two, doing `devour zathura "File\ Space.pdf"`, but that's a bit tedious. So using some google-fu I found a way to open files with a space.