### PR TITLE
Handle args with spaces, remove second shell

### DIFF
--- a/devour.sh
+++ b/devour.sh
@@ -4,6 +4,6 @@
 
 WID=$(xdo id)
 
-$SHELL -i -c "xdo hide
-$* > /dev/null 2>&1
-xdo show $WID"
+xdo hide
+"$@" > /dev/null 2>&1
+xdo show $WID


### PR DESCRIPTION
[from gnu.org](https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html):

> ($*) Expands to the positional parameters, starting from one. When the expansion is not within double quotes, each positional parameter expands to a separate word. In contexts where it is performed, those words are subject to further word splitting and pathname expansion.
($@) ... When the expansion occurs within double quotes, and word splitting is performed, each parameter expands to a separate word. That is, "$@" is equivalent to "$1" "$2" …. 

`$*` here does not handle arguments with spaces in them, e.g. `devour mpv a\ video\ with\ spaces.mp4`, but `"$@"` does.

`$SHELL -c "foo"` spawns another shell process, which uses more resources than is necessary. Using the same shell process that is running the script should work just fine.