### PR TITLE
Remove the creation of an unnecessary sub-shell to improve performance

### DIFF
--- a/devour.sh
+++ b/devour.sh
@@ -14,7 +14,7 @@ FILE="${ARGS##* -- }"
 
 WID=$(xdo id)
 
-$SHELL -i -c "xdo hide
+sh -i -c "xdo hide
 $CMD $SAFEFILE > /dev/null 2>&1
 xdo show $WID
 exit"

--- a/devour.sh
+++ b/devour.sh
@@ -14,7 +14,7 @@ FILE="${ARGS##* -- }"
 
 WID=$(xdo id)
 
-sh -i -c "xdo hide
-$CMD $SAFEFILE > /dev/null 2>&1
-xdo show $WID
-exit"
+xdo hide &&
+    $CMD $SAFEFILE > /dev/null 2>&1 &&
+    xdo show $WID &&
+    exit


### PR DESCRIPTION
While using devour, I realized it was performing somewhat slower than it should, so I looked at its code and saw that it creates a sub-shell using the user's pre-defined $SHELL. Devour is not run interactively, so I do not see why xdo has to be called within its own shell, as this might cause devour to operate less efficiently than if it were to only be run within a single instance of a POSIX-compliant shell, especially if the user is using a slower shell like fish or they are using zsh or bash with a lot of plugins. Thanks for this cool utility by the way!