### PR TITLE
Corrected link to tide

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ sudo make uninstall
 | ------------------------------------------------------- | ------------------------------- |
 | [bolt](https://github.com/salman-abedin/bolt)           | The launcher wrapper            |
 | [uniblocks](https://github.com/salman-abedin/uniblocks) | The status bar wrapper          |
-| [tide](https://github.com/salman-abedin/puri)           | Minimal Transmission CLI client |
+| [tide](https://github.com/salman-abedin/tide)           | Minimal Transmission CLI client |
 | [puri](https://github.com/salman-abedin/puri)           | Minimal URL launcher            |
 | [crystal](https://github.com/salman-abedin/crystal)     | The transparent setup           |
 | [Magpie](https://github.com/salman-abedin/magpie)       | The dotfiles                    |


### PR DESCRIPTION
I noticed the link to [tide](https://github.com/salman-abedin/tide) in the README led to [puri](https://github.com/salman-abedin/puri) instead. I know its meaningless, but it annoyed me enough to make this PR haha...