### PR TITLE
Added shell aliases patch for v12

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ devour CMD ...
 
 ```sh
 cd devour
-patch -s < devour-shellalias-10.0.diff    # Add the feature
-patch -s -R < devour-shellalias-10.0.diff # Remove the feature
+patch -s < devour-shellalias-12.diff    # Add the feature
+patch -s -R < devour-shellalias-12.diff # Remove the feature
 sudo make install                      # Reinstall
 ```
+
+Use `devour-shellalias-10.0.diff` for previous versions of `devour`.
 
 ## Pro Tip
 

--- a/devour-shellalias-12.diff
+++ b/devour-shellalias-12.diff
@@ -1,0 +1,17 @@
+--- devour.c	2020-11-10 11:18:04.550682287 +0200s
+@@ -14,6 +14,7 @@
+   char *arg;
+   char cmd[1024] = {0};
+ 
++  strcat(cmd, "$SHELL -i -c '");
+   while ((arg = *++argv)) {
+     while ((arg_char = *arg++)) {
+       if (strchr(UNSAFE_CHARS, arg_char))
+@@ -22,6 +23,7 @@
+     }
+     strcat(cmd, " ");
+   }
++  strcat(cmd, "> /dev/null 2>&1; exit'");
+   system(cmd);
+ }
+


### PR DESCRIPTION
Hi,
I was using the patch for the shell aliases, but it does not apply anymore for devour 12.
So far, I have updated the patch and shell aliases work again in my repository.

Does devour 12 have another solution to run the shell aliases instead of patching it?