### PR TITLE
Fix for embeded terminal window

### DIFF
--- a/devour.c
+++ b/devour.c
@@ -27,13 +27,21 @@ void run_command(char **argv) {
 
 int main(int argc, char **argv) {
   int rev;
-  Window win;
+  unsigned nc;
+  Window win, root, *ch;
   Display *dis = XOpenDisplay(0);
 
   XGetInputFocus(dis, &win, &rev);
+
+  /* This is to ensure correct behavior with an embeded terminal window e.g. using Suckless' tabbed */
+  if(rev == RevertToParent)
+    XQueryTree(dis, win, &root, &win, &ch, &nc);
+
   XUnmapWindow(dis, win);
   XFlush(dis);
+
   run_command(argv);
+
   XMapWindow(dis, win);
   XCloseDisplay(dis);
 


### PR DESCRIPTION
Devour does not work when I used a terminal embedded inside Suckless tabbed ( https://tools.suckless.org/tabbed/ ).
In that case the win variable was set to the terminal window instead of the tabbed window.
I added a simple check to detect this and select parent of win (tabbed).